### PR TITLE
Prevent garbage from being appended to comment

### DIFF
--- a/setfcomment/setfcomment.c
+++ b/setfcomment/setfcomment.c
@@ -309,6 +309,7 @@ pascal OSErr MoreFESetComment(const FSRef *pFSRefPtr, const FSSpecPtr pFSSpecPtr
 	{
 		char* dataPtr = NewPtr(pCommentStr[0] + 1);
         strncpy(dataPtr, (char*)pCommentStr + 1, pCommentStr[0]);
+        dataPtr[pCommentStr[0]] = 0;
 		anErr = AEBuildAppleEvent(
 			        kAECoreSuite,kAESetData,
 					typeApplSignature,&gFinderSignature,sizeof(OSType),


### PR DESCRIPTION
NewPtr does not guarantee the memory block is zeroed, so explicitly
zero the last byte to terminate the C string.

Closes #7